### PR TITLE
確認メールが届かない

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ApplicationMailer
-  default from: "no-reply@aws-intro-sample.com"
+  default from: "no-reply@#{ENV['AWS_INTRO_SAMPLE_SMTP_DOMAIN']}"
 
   def account_activation(user)
     @user = user


### PR DESCRIPTION
通知メール用のメールアドレスを構築するときに、環境変数の値を使っていなかったため、常にドメインが"aws-intro-sample.com"になっていたのが原因。修正してリポジトリにPUSHした。